### PR TITLE
chore: hardcode deploy path in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "validate": "bun run scripts/validate-plugin.ts",
     "test": "bun test",
     "version": "bun run version-bump.ts",
-    "deploy": "cp dist/main.js manifest.json styles.css \"$CALENDAR_DEPLOY_DIR\""
+    "deploy": "cp dist/main.js manifest.json styles.css ~/source/mine/notes/.obsidian/plugins/calendar/"
   },
   "dependencies": {
     "svelte": "^5.53.0"


### PR DESCRIPTION
## Summary

- Replace `$CALENDAR_DEPLOY_DIR` env var with the actual vault path in the deploy script
- Removes unnecessary indirection since this is a personal plugin repo with a stable vault location

## Test plan

- [ ] Run `bun run deploy` and verify files are copied to `~/source/mine/notes/.obsidian/plugins/calendar/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)