### PR TITLE
fix: guard unguarded access to _bundledLocaleWeekSpec.dow

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -116,7 +116,7 @@ export class CalendarSettingsTab extends PluginSettingTab {
     const { moment } = window;
 
     const localizedWeekdays = moment.weekdays();
-    const localeWeekStartNum = window._bundledLocaleWeekSpec.dow;
+    const localeWeekStartNum = window._bundledLocaleWeekSpec?.dow ?? 0;
     const localeWeekStart = moment.weekdays()[localeWeekStartNum];
 
     new Setting(this.containerEl)


### PR DESCRIPTION
## Summary
- Adds optional chaining and a default value (`0`) when accessing `window._bundledLocaleWeekSpec.dow` in `addWeekStartSetting()`
- Prevents `TypeError` crash if the settings tab opens before locale initialization completes

Closes #8

## Test plan
- [x] All existing tests pass (27/27)
- [x] `bun run check` passes (typecheck + biome + svelte-check)
- [ ] Open settings tab immediately on plugin load to verify no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)