### PR TITLE
refactor: deduplicate subscriptions in Month.svelte

### DIFF
--- a/src/components/Month.svelte
+++ b/src/components/Month.svelte
@@ -51,27 +51,19 @@
   let metadata: Promise<IDayMetadata[]> | null = $state(null);
   let file: TFile | null = $state(null);
 
+  function refresh() {
+    file = fileCache.getFile($displayedMonth, "month");
+    metadata = fileCache.getEvaluatedMetadata(
+      "month",
+      $displayedMonth,
+      getSourceSettings,
+    );
+  }
+
   $effect(() => {
-    const unsub1 = fileCache.store.subscribe(() => {
-      file = fileCache.getFile($displayedMonth, "month");
-      metadata = fileCache.getEvaluatedMetadata(
-        "month",
-        $displayedMonth,
-        getSourceSettings,
-      );
-    });
-    const unsub2 = displayedMonth.subscribe(() => {
-      file = fileCache.getFile($displayedMonth, "month");
-      metadata = fileCache.getEvaluatedMetadata(
-        "month",
-        $displayedMonth,
-        getSourceSettings,
-      );
-    });
-    return () => {
-      unsub1();
-      unsub2();
-    };
+    // Reading $displayedMonth here makes Svelte re-run the effect on month changes
+    $displayedMonth;
+    return fileCache.store.subscribe(() => refresh());
   });
 
   function handleHover(event: PointerEvent) {


### PR DESCRIPTION
## Summary
- Extracts duplicated fetch logic into a `refresh()` helper
- Combines two independent subscriptions into a single `$effect` that tracks both `displayedMonth` and `fileCache.store`
- Eliminates redundant work when both sources change in the same tick

Closes #9

## Test plan
- [x] All existing tests pass (27/27)
- [x] `bun run check` passes (typecheck + biome + svelte-check)
- [ ] Verify month navigation still updates file/metadata correctly
- [ ] Verify file cache changes still reflect in the month header

🤖 Generated with [Claude Code](https://claude.com/claude-code)