### PR TITLE
chore: use startOfWeek consistently in WeekNum handlers

### DIFF
--- a/src/components/WeekNum.svelte
+++ b/src/components/WeekNum.svelte
@@ -50,10 +50,10 @@
 
   $effect(() => {
     return fileCache.store.subscribe(() => {
-      file = fileCache.getFile(days[0], "week");
+      file = fileCache.getFile(startOfWeek, "week");
       metadata = fileCache.getEvaluatedMetadata(
         "week",
-        days[0],
+        startOfWeek,
         getSourceSettings,
       );
     });
@@ -61,7 +61,7 @@
 
   function handleHover(event: PointerEvent) {
     if (event.target) {
-      onHover?.("week", days[0], file, event.target, isMetaPressed(event));
+      onHover?.("week", startOfWeek, file, event.target, isMetaPressed(event));
     }
   }
 </script>
@@ -73,14 +73,14 @@
         role="button"
         tabindex="0"
         class="week-num"
-        class:active={selectedId === getDateUID(days[0], 'week')}
+        class:active={selectedId === getDateUID(startOfWeek, 'week')}
         draggable={!!file}
         onclick={onClick &&
           ((e) => onClick('week', startOfWeek, file, isMetaPressed(e)))}
         onkeydown={onClick &&
           ((e) => (e.key === 'Enter' || e.key === ' ') && onClick('week', startOfWeek, file, false))}
         oncontextmenu={onContextMenu &&
-          ((e) => onContextMenu('week', days[0], file, e))}
+          ((e) => onContextMenu('week', startOfWeek, file, e))}
         ondragstart={file ? (event) => fileCache.onDragStart(event, file!) : undefined}
         onpointerenter={handleHover}
       >


### PR DESCRIPTION
## Summary
- Replaces all `days[0]` references with `startOfWeek` in WeekNum.svelte
- Affects `getFile`, `getEvaluatedMetadata`, `onHover`, `onContextMenu`, and `getDateUID`
- Eliminates confusion about which date derivation is canonical for week operations

Closes #10

## Test plan
- [x] All existing tests pass (27/27)
- [x] `bun run check` passes (typecheck + biome + svelte-check)
- [ ] Verify week number click/hover/context menu works correctly at month boundaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)