### PR TITLE
chore: rename appHasPeriodicNotesPluginLoaded to appHasPeriodicNotesWeeklyEnabled

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -3,7 +3,7 @@ import { configureGlobalMomentLocale } from "./components/localization";
 import { VIEW_TYPE_CALENDAR } from "./constants";
 import { tryToCreateWeeklyNote } from "./io/notes";
 import {
-  appHasPeriodicNotesPluginLoaded,
+  appHasPeriodicNotesWeeklyEnabled,
   CalendarSettingsTab,
   type ISettings,
 } from "./settings";
@@ -50,7 +50,7 @@ export default class CalendarPlugin extends Plugin {
       name: "Open Weekly Note",
       checkCallback: (checking) => {
         if (checking) {
-          return !appHasPeriodicNotesPluginLoaded();
+          return !appHasPeriodicNotesWeeklyEnabled();
         }
         tryToCreateWeeklyNote(window.moment(), false, this.options);
       },

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -35,7 +35,7 @@ export const defaultSettings = Object.freeze({
   localeOverride: "system-default",
 });
 
-export function appHasPeriodicNotesPluginLoaded(): boolean {
+export function appHasPeriodicNotesWeeklyEnabled(): boolean {
   // biome-ignore lint/suspicious/noExplicitAny: Obsidian API lacks type
   const periodicNotes = (<any>window.app).plugins.getPlugin("periodic-notes");
   return !!periodicNotes?.settings?.weekly?.enabled;
@@ -74,7 +74,7 @@ export class CalendarSettingsTab extends PluginSettingTab {
 
     if (
       this.plugin.options.showWeeklyNote &&
-      !appHasPeriodicNotesPluginLoaded()
+      !appHasPeriodicNotesWeeklyEnabled()
     ) {
       this.containerEl.createEl("h3", {
         text: "Weekly Note Settings",


### PR DESCRIPTION
## Summary
- Renames `appHasPeriodicNotesPluginLoaded()` → `appHasPeriodicNotesWeeklyEnabled()` in `settings.ts` and `main.ts`
- The function checks if weekly notes are enabled, not if the plugin is loaded — name now matches behavior

Closes #11

## Test plan
- [x] All existing tests pass (27/27)
- [x] `bun run check` passes (typecheck + biome + svelte-check)
- [x] No remaining references to old name

🤖 Generated with [Claude Code](https://claude.com/claude-code)