### PR TITLE
chore: replace unsafe double cast on Svelte mount return

### DIFF
--- a/src/view.ts
+++ b/src/view.ts
@@ -66,7 +66,7 @@ export default class CalendarView extends ItemView {
 
     const fileCache = new PeriodicNotesCache(this, sources);
 
-    this.calendar = mount(Calendar, {
+    const cal = mount(Calendar, {
       // biome-ignore lint/suspicious/noExplicitAny: Obsidian API lacks type
       target: (this as any).contentEl,
       props: {
@@ -76,7 +76,11 @@ export default class CalendarView extends ItemView {
         onClick: this.onClick.bind(this),
         onContextMenu: this.onContextMenu.bind(this),
       },
-    }) as unknown as CalendarExports;
+    });
+    if (!("tick" in cal && "setDisplayedMonth" in cal)) {
+      throw new Error("Calendar component missing expected exports");
+    }
+    this.calendar = cal as CalendarExports;
   }
 
   private onHover(


### PR DESCRIPTION
## Summary
- Removes `as unknown as CalendarExports` double cast from `mount()` return
- Adds runtime assertion checking that `tick` and `setDisplayedMonth` exist before casting
- API mismatches now fail fast at mount time with a clear error

Closes #12

## Test plan
- [x] All existing tests pass (27/27)
- [x] `bun run check` passes (typecheck + biome + svelte-check)
- [ ] Verify calendar view opens without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)